### PR TITLE
Update mdoc handover for OID4VP draft 24

### DIFF
--- a/app/src/main/java/com/credman/cmwallet/openid4vp/OpenId4VP.kt
+++ b/app/src/main/java/com/credman/cmwallet/openid4vp/OpenId4VP.kt
@@ -118,15 +118,27 @@ class OpenId4VP(val request: String) {
     }
 
     fun getHandover(origin: String): List<Any> {
+        /**
+         * Shape of `OpenID4VPDCAPIHandover[0]`
+         *
+         * See https://openid.net/specs/openid-4-verifiable-presentations-1_0-24.html#appendix-B.3.4.1
+         */
+        val oid4vpHandoverIdentifier = "OpenID4VPDCAPIHandover";
+
+        /**
+         * Shape of `OpenID4VPDCAPIHandoverInfo`
+         *
+         * See https://openid.net/specs/openid-4-verifiable-presentations-1_0-24.html#appendix-B.3.4.1
+         */
         val handoverData = listOf(
+            origin,
             clientId,
-            nonce,
-            origin
+            nonce
         )
 
         val md = MessageDigest.getInstance("SHA-256")
         return listOf(
-            "OID4VPDCAPIHandover",
+            oid4vpHandoverIdentifier,
             md.digest(cborEncode(CborTag(24, cborEncode(handoverData))))
         )
     }


### PR DESCRIPTION
This PR updates the wallet's mdoc session transcript (see **9.1.5.1 Session transcript** in 18013-5) `handover` generation to reflect the latest shape of it as per OID4VP draft 24:

See https://openid.net/specs/openid-4-verifiable-presentations-1_0-24.html#appendix-B.3.4.1