### PR TITLE
Try to update to newest DC API types

### DIFF
--- a/app/src/main/java/com/credman/cmwallet/getcred/GetCredentialActivity.kt
+++ b/app/src/main/java/com/credman/cmwallet/getcred/GetCredentialActivity.kt
@@ -176,7 +176,7 @@ class GetCredentialActivity : FragmentActivity() {
                         Json.decodeFromString<DigitalCredentialRequestOptions>(it.requestJson)
                     if (entryId == "ISSUANCE") {
                         val openId4VPRequest = OpenId4VP(
-                            digitalCredentialRequestOptions.providers[0].request,
+                            digitalCredentialRequestOptions.requests[0].data,
                             computeClientId(request.callingAppInfo)
                         )
                         startActivityForResult(
@@ -314,13 +314,13 @@ class GetCredentialActivity : FragmentActivity() {
 
     @Serializable
     data class DigitalCredentialRequestOptions(
-        val providers: List<DigitalCredentialRequest>
+        val requests: List<DigitalCredentialRequest>
     )
 
     @Serializable
     data class DigitalCredentialRequest(
         val protocol: String,
-        val request: String
+        val data: String
     )
 
     private fun processDigitalCredentialOption(
@@ -337,7 +337,7 @@ class GetCredentialActivity : FragmentActivity() {
             "digitalCredentialRequestOptions $digitalCredentialRequestOptions"
         )
 
-        val provider = digitalCredentialRequestOptions.providers[providerIdx]
+        val provider = digitalCredentialRequestOptions.requests[providerIdx]
 
         Log.i(
             "GetCredentialActivity",
@@ -345,7 +345,7 @@ class GetCredentialActivity : FragmentActivity() {
         )
         when (provider.protocol) {
             "openid4vp" -> {
-                val openId4VPRequest = OpenId4VP(provider.request, computeClientId(request!!.callingAppInfo))
+                val openId4VPRequest = OpenId4VP(provider.data, computeClientId(request!!.callingAppInfo))
                 Log.i("GetCredentialActivity", "nonce ${openId4VPRequest.nonce}")
                 val matchedCredential =
                     openId4VPRequest.performQueryOnCredential(selectedCredential)

--- a/matcher/openid4vp.c
+++ b/matcher/openid4vp.c
@@ -47,7 +47,7 @@ int main() {
     printf("Request JSON %s\n", cJSON_Print(dc_request));
 
     // Parse each top level request looking for OpenID4VP requests
-    cJSON* requests = cJSON_GetObjectItem(dc_request, "providers"); // TODO: This has changed in the latest spec
+    cJSON* requests = cJSON_GetObjectItem(dc_request, "requests");
     int requests_size = cJSON_GetArraySize(requests);
 
     int matched = 0;
@@ -61,7 +61,7 @@ int main() {
         char* protocol = cJSON_GetStringValue(cJSON_GetObjectItem(request, "protocol"));
         if (strcmp(protocol, PROTOCOL_OPENID4VP_1_0) == 0) {
             // We have an OpenID4VP request
-            cJSON* data = cJSON_GetObjectItem(request, "request"); // TODO: This has changed in the latest spec
+            cJSON* data = cJSON_GetObjectItem(request, "data");
 
             // TODO: Won't need to do this conversion in the latest spec.
             char* data_json_string = cJSON_GetStringValue(data);


### PR DESCRIPTION
DC API calls in Chrome Canary 136 now support the newest DC API call structure as detailed here:

https://wicg.github.io/digital-credentials/#extensions-to-credentialrequestoptions-dictionary

After updating Verifier-side calls to `navigator.credentials.get({ digital: {...} })` I can get Chrome to pop up the QR code, and scan it with Android as expected, however CMWallet won't offer up anything.

This PR tries to fix this by updating CMWallet's knowledge of DC API types to the latest structures in the link above. However I still can't get credentials to show up.

Here is an example of request options using the **latest** DC API structures that I'm trying to get CMWallet to recognize:

```js
{
  digital: {
    requests: [
      {
        protocol: 'openid4vp',
        data: {
          response_type: 'vp_token',
          response_mode: 'dc_api',
          client_id: 'web-origin:http://localhost:8000',
          nonce: 'WtiMRaVnYRMj5myC5F4aru7MWVWrXInDd8vRg-ZdHPQ',
          dcql_query: {
            credentials: [
              {
                id: 'cred1',
                format: 'mso_mdoc',
                meta: { doctype_value: 'org.iso.18013.5.1.mDL' },
                claims: [
                  { path: ['org.iso.18013.5.1', 'family_name'] },
                  { path: ['org.iso.18013.5.1', 'given_name'] },
                ],
              },
            ],
          },
        },
      },
    ],
  },
}
```

Logcat won't show any logging from the app when I scan the QR code; I'm not sure if I'm doing something wrong or if I need to filter by some other value to see how Android is negotiating with CMWallet to determine what credentials to offer up. I'm flying blind as a result and updating low-hanging fruit like the values in this PR.